### PR TITLE
Fixed deprecation warning when passing null to unserialize() on newer…

### DIFF
--- a/src/Extensions/MemberProfileExtension.php
+++ b/src/Extensions/MemberProfileExtension.php
@@ -33,7 +33,7 @@ class MemberProfileExtension extends DataExtension
 
     public function getPublicFields()
     {
-        return (array) unserialize(($this->owner->getField('PublicFieldsRaw')) ? $this->owner->getField('PublicFieldsRaw') : '');
+        return (array) unserialize($this->owner->getField('PublicFieldsRaw') ?: '');
     }
 
     public function setPublicFields($fields)

--- a/src/Extensions/MemberProfileExtension.php
+++ b/src/Extensions/MemberProfileExtension.php
@@ -33,7 +33,7 @@ class MemberProfileExtension extends DataExtension
 
     public function getPublicFields()
     {
-        return (array) unserialize($this->owner->getField('PublicFieldsRaw'));
+        return (array) unserialize(($this->owner->getField('PublicFieldsRaw')) ? $this->owner->getField('PublicFieldsRaw') : '');
     }
 
     public function setPublicFields($fields)


### PR DESCRIPTION
Fixes an issue in newer versions of php that was causing this error:

`unserialize(): Passing null to parameter #1 ($data) of type string is deprecated`